### PR TITLE
setType only generates necessary breakpoints

### DIFF
--- a/scss/01-config/03-mixins/_01-type.scss
+++ b/scss/01-config/03-mixins/_01-type.scss
@@ -70,7 +70,18 @@
       $minFontSize: $minDesktopClamp,
       $maxFontSize: $fontSize--desktop-large,
       $minWidth: $tl,
-      $maxWidth: $lf
+      $maxWidth: $lf,
+      $minBreakpoint: false,
+      $maxBreakpoint: false
     );
   }
+
+  @include fluidType(
+    $minFontSize: $minDesktopClamp,
+    $maxFontSize: $fontSize--desktop-large,
+    $minWidth: $tl,
+    $maxWidth: $lf,
+    $minBreakpoint: false,
+    $midBreakpoint: false
+  );
 }


### PR DESCRIPTION
`setType` is currently generating an unnecessary breakpoint that outputs the following (on an h1, for example)

```scss
@media (min-width: 1024px) and (max-width: 1024px) {
  h1, .h1 {
    font-size: 2.4rem;
  }
}
```

`setType` is also generating an unnecessary conditional breakpoint of `(min-width: 1024px) and (min-width: 1600px)` (on an h1, for example)
```scss
@media (min-width: 1024px) and (min-width: 1600px) {
  h1, .h1 {
    font-size: 3.75rem;
  }
}
```

this fixes both of those to remove the unnecessary breakpoints to where the output should be the following (on an h1, for example). comments have been added for what each block suggests (let me know if this is not the expected behavior):

```scss
// stop scaling at and below 320px (unchanged)
@media (max-width: 320px) {
  h1, .h1 {
    font-size: 1.7066666667rem;
  }
}

// mobile-first default rule — allows scaling between 321px and 767px (unchanged)
h1, .h1 {
  font-size: calc(
      1.7066666667rem +
        (65.536 - 27.3066666667) *
        ((100vw - 320px) / (768 - 320))
    );
}

// stop scaling between 768px and 1023px (unchanged)
@media (min-width: 768px) {
  h1, .h1 {
    font-size: 2.4rem;
  }
}

// scale between 1024px and 1599px (unchanged)
@media (min-width: 1024px) {
  h1, .h1 {
    font-size: calc(
      2.4rem +
        (60 - 38.4) *
        ((100vw - 1024px) / (1600 - 1024))
    );
  }
}

// stop scaling above 1600px
@media (min-width: 1600px) {
  h1, .h1 {
    font-size: 3.75rem;
  }
}
```

https://kni-scss-git-unnecessary-breakpoint-cleanup-kni.vercel.app/