### PR TITLE
switch default styles to mixins for overwrite capability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kni-scss",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kni-scss",
-      "version": "1.0.2",
+      "version": "1.0.4",
       "license": "ISC",
       "dependencies": {
         "husky": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kni-scss",
-  "version": "1.0.2",
+  "version": "1.0.4",
   "description": "kni css",
   "main": "scss",
   "engines": {

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,5 @@
+# Pre-merge checklist
+
+## Required items for every deploy
+
+- [ ] Update `package.json` and `package-lock.json` version accordingly.

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,5 +1,3 @@
-# Pre-merge checklist
-
-## Required items for every deploy
+## Required items for every merge
 
 - [ ] Update `package.json` and `package-lock.json` version accordingly.

--- a/scss/01-config/03-mixins/_01-type.scss
+++ b/scss/01-config/03-mixins/_01-type.scss
@@ -87,3 +87,52 @@
     $midBreakpoint: false
   );
 }
+
+@mixin h {
+  font-family: $headingFontStack;
+  font-weight: $headingFont-bold;
+  color: $black;
+  line-height: 1.1em;
+}
+
+@mixin h1 {
+  @include setType(32, 48);
+}
+
+@mixin h2 {
+  @include setType(26, 40);
+}
+
+@mixin h3 {
+  @include setType(22, 33);
+}
+
+@mixin h4 {
+  @include setType(20, 27);
+}
+
+@mixin h5 {
+  @include setType(18, 23);
+}
+
+@mixin h6 {
+  @include setType(16, 20);
+}
+
+@mixin p {
+  color: $gray-200;
+  line-height: 1.4;
+  @include setType(14, 16, 95%);
+}
+
+@mixin p--smallest {
+  @include setType(10, 12, 100%);
+}
+
+@mixin p--small {
+  @include setType(12, 14, 100%);
+}
+
+@mixin p--large {
+  @include setType(16, 18, 100%);
+}

--- a/scss/02-base/02-normalize/_index.scss
+++ b/scss/02-base/02-normalize/_index.scss
@@ -56,11 +56,23 @@ body {
 }
 
 html {
-  scroll-behavior: smooth;
+  font-family: $bodyFontStack;
+  font-size: em($baseFontSize);
+  font-weight: $bodyFont-regular;
 }
 
 body {
   margin: 0;
+}
+
+p,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  overflow-wrap: break-word;
 }
 
 h1,

--- a/scss/02-base/04-type/_index.scss
+++ b/scss/02-base/04-type/_index.scss
@@ -1,19 +1,3 @@
-html {
-  font-family: $bodyFontStack;
-  font-size: em($baseFontSize);
-  font-weight: $bodyFont-regular;
-}
-
-p,
-h1,
-h2,
-h3,
-h4,
-h5,
-h6 {
-  overflow-wrap: break-word;
-}
-
 h1,
 .h1,
 h2,
@@ -26,51 +10,54 @@ h5,
 .h5,
 h6,
 .h6 {
-  font-family: $headingFontStack;
-  font-weight: $headingFont-bold;
-  color: $black;
-  line-height: 1.1em;
+  @include h;
 }
 
 h1,
 .h1 {
-  @include setType(32, 48);
+  @include h1;
 }
 
 h2,
 .h2 {
-  @include setType(26, 40);
+  @include h2;
 }
 
 h3,
 .h3 {
-  @include setType(22, 33);
+  @include h3;
 }
 
 h4,
 .h4 {
-  @include setType(20, 27);
+  @include h4;
 }
 
 h5,
 .h5 {
-  @include setType(18, 23);
+  @include h5;
 }
 
 h6,
 .h6 {
-  @include setType(16, 20);
+  @include h6;
 }
 
 p,
 .p {
-  color: $gray-200;
-  line-height: 1.4;
-  @include setType(14, 16, 95%);
+  @include p;
 }
 
 .p {
   &--smallest {
-    @include setType(10, 12, 100%);
+    @include p--smallest;
+  }
+
+  &--small {
+    @include p--small;
+  }
+
+  &--large {
+    @include p--large;
   }
 }


### PR DESCRIPTION
switched default styles to mixins for overwriting capability and moved a couple of blocks to `normalize` that made more sense there. no style changes, just sass structure https://kni-scss-git-type-mixins-kni.vercel.app/.

## Required items for every merge

- [x] Update `package.json` and `package-lock.json` version accordingly.