### PR TITLE
add fluid type class

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kni-scss",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kni-scss",
-      "version": "6.0.0",
+      "version": "7.0.0",
       "license": "ISC",
       "dependencies": {
         "eslint": "^8.23.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "kni-scss",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "kni css",
   "main": "scss",
   "engines": {

--- a/scss/02-base/04-type/_index.scss
+++ b/scss/02-base/04-type/_index.scss
@@ -49,7 +49,8 @@ th,
 title,
 blockquote,
 time,
-input {
+input,
+.fluid-type {
   --fontSizeMin: calc(var(--fontSize) * var(--siteMin) / var(--siteBasis));
   --fontSizeMax: calc(var(--fontSize) * var(--siteMax) / var(--siteBasis));
   --fontSizeMinClamp: var(--fontSizeMin);


### PR DESCRIPTION
## Notes

Adding the `fluid-type` class so that the fluid type system can be used on elements outside of the default list.

### Use case

On a project, we're using a treemaps library that renders HTML text via SVG inside the boxes, but the `text` and `tspan` elements aren't in the element list. Adding them to the list would introduce the potential of breaking SVGs with type elements inside them that should NOT scale fluidly and use the default method of scaling with their boxes. A major version has been incremented here since this has the potential to break SVGs on existing builds, and the `.fluid-type` class is generic enough that some builds could already be using this class for other things.

## Required items for every merge

- [x] Update `package.json` and `package-lock.json` version accordingly.